### PR TITLE
Ensure anaconda_mode can import jsonrpc, jedi

### DIFF
--- a/anaconda_mode.py
+++ b/anaconda_mode.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import sys
 if '' not in sys.path:
-    sys.path.append('')  # Ensure we can import, e.g., jsonrpc from CWD
+    sys.path.insert(0, '')  # Ensure we can import, e.g., jsonrpc from CWD
 
 from jsonrpc import dispatcher, JSONRPCResponseManager
 


### PR DESCRIPTION
If `sys.path` does not include an empty string, Python won't look for modules in the same directory as `anaconda_mode.py`. It isn't terribly uncommon for build tools/development environments to specify `sys.path` in a way that prevents such imports; for compatibility-sake, just make sure the empty string is present.
