### PR TITLE
Find jedi and jsonrpc when installed with el-get.

### DIFF
--- a/anaconda_mode.py
+++ b/anaconda_mode.py
@@ -4,6 +4,16 @@ import sys
 if '' not in sys.path:
     sys.path.insert(0, '')  # Ensure we can import, e.g., jsonrpc from CWD
 
+sys.path.insert(0, os.path.abspath(os.path.join( 
+    os.path.dirname(__file__),
+    "vendor")))
+
+sys.path.insert(0, os.path.abspath(os.path.join( 
+    os.path.dirname(__file__),
+    "vendor",
+    "jedi")))
+
+
 from jsonrpc import dispatcher, JSONRPCResponseManager
 
 try:


### PR DESCRIPTION
When i installed anaconda-mode using el-get. I got the following error message:

 "Unable to run anaconda_mode.py" with args (candidates import)

The changes in this pull request fix the install using el-get.
