### PR TITLE
Fixed jedi version

### DIFF
--- a/anaconda_mode.py
+++ b/anaconda_mode.py
@@ -19,7 +19,7 @@ missing_dependencies = []
 try:
     import jedi
 except ImportError:
-    missing_dependencies.append('jedi==0.8.1')
+    missing_dependencies.append('jedi==0.8.1-final0')
 
 try:
     import jsonrpc
@@ -34,7 +34,7 @@ if missing_dependencies:
     import jedi
     import jsonrpc
 
-assert jedi.__version__ == '0.8.1', 'Jedi version does not match 0.8.1'
+assert jedi.__version__ == '0.8.1-final0', 'Jedi version does not match 0.8.1-final0'
 assert jsonrpc.__version__ == '1.8.1', 'JSON RPC version does not match 1.8.1'
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # This file exists only for requires.io purpose.
-jedi==0.8.1
+jedi==0.8.1-final0
 json-rpc==1.8.1


### PR DESCRIPTION
Latest version of jedi is `0.8.1-final0` and not `0.8.1` this assert broke anaconda.
e200de42cc478f0a5f86cc634c4f683d5c00f4e8 caused this.