### PR TITLE
Fallback-behavior on dependencies installed via pip

### DIFF
--- a/anaconda_mode.py
+++ b/anaconda_mode.py
@@ -131,7 +131,7 @@ def process_definitions(f):
         def get_description(d):
             if d.module_path not in cache:
                 with open(d.module_path, 'r') as file:
-                    cache[d.module_path] = file.read().splitlines()
+                    cache[d.module_path] = file.read().splitlines() or ['']
 
             return cache[d.module_path][d.line - 1]
 

--- a/anaconda_mode.py
+++ b/anaconda_mode.py
@@ -22,7 +22,9 @@ from subprocess import Popen
 
 project_path = dirname(abspath(__file__))
 
-sys.path.insert(0, project_path)
+if project_path in sys.path:
+    sys.path.remove(project_path)
+sys.path.append(project_path)
 
 missing_dependencies = []
 


### PR DESCRIPTION
Jedi is not frequently released, and sometimes you wish to use a more recent version. If anaconda installs jedi at some point, it will use that version even if there is a newer version in sys.path.

With this fix, the dependencies installed by anaconda will be used as a last resort.