### PR TITLE
Add defvaralias to python.el virtualenv variable

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -58,11 +58,16 @@
 (defvar anaconda-mode-connection nil
   "Json Rpc connection to anaconda_mode process.")
 
+(defvaralias 'anaconda-mode-virtualenv-variable (if (version< emacs-version "25.1")
+                                                    'python-shell-virtualenv-path
+                                                  'python-shell-virtualenv-root)
+  "Alias to `python.el' virtualenv variable.")
+
 (defun anaconda-mode-python ()
   "Detect python executable."
   (let ((python (if (eq system-type 'windows-nt) "pythonw" "python"))
         (bin-dir (if (eq system-type 'windows-nt) "Scripts" "bin")))
-    (--if-let python-shell-virtualenv-path
+    (--if-let anaconda-mode-virtualenv-variable
         (f-join it bin-dir python)
       python)))
 


### PR DESCRIPTION
Given that the variable `python-shell-virtualenv-path` has been [renamed](https://lists.gnu.org/archive/html/emacs-diffs/2014-11/msg00196.html) this alias is to keep compatibility with future versions.