### PR TITLE
Take virtualenv into account when checking for pip

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -113,8 +113,9 @@ Return nil if it run under proper environment."
 
 (defun anaconda-mode-bootstrap ()
   "Run anaconda-mode-command process."
-  (unless (executable-find "pip")
-    (error "Unable to find pip executable"))
+  (let ((exec-path (python-shell-calculate-exec-path)))
+    (unless (executable-find "pip")
+      (error "Unable to find pip executable")))
   (setq anaconda-mode-process
         (start-process
          "anaconda_mode"


### PR DESCRIPTION
A `pip` executable might exist only in the current virtualenv.