### PR TITLE
Fix the missing interactive statement

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -614,6 +614,7 @@ to the beginning of buffer before definitions navigation."
 
 (defun anaconda-mode-go-back ()
   "Jump backward if buffer was navigated from `anaconda-mode' command."
+  (interactive)
   (if anaconda-mode-go-back-definition
       (anaconda-mode-find-file anaconda-mode-go-back-definition)
     (error "No previous buffer")))


### PR DESCRIPTION
This statement make the function an interactively-callable command.

Without it, we can't go back to previous point, and Emacs will issue an `Wrong type argument: commandp, anaconda-mode-go-back` error.