### PR TITLE
fix ipython bootstrapping by calling pip with -c flag

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -133,9 +133,9 @@ except DistributionNotFound:
   "Check if `anaconda-mode' server is installed or not.")
 
 (defvar anaconda-mode-install-server-command
-  (list "-m" "pip" "install" "-t" "."
-        (concat "anaconda_mode" "=="
-                anaconda-mode-server-version))
+  (list "-c" (concat "import pip; pip.main(['install', '-t', '.', "
+                     "'anaconda_mode" "=="
+                     anaconda-mode-server-version "'])"))
   "Install `anaconda_mode' server.")
 
 (defun anaconda-mode-host ()


### PR DESCRIPTION
This should fix #104 by installing the package inside python code, thus not relying only on the `-c` flag of the interpreter.