### PR TITLE
Update directions for downgrading Jedi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ try to downgrade jedi version down to 0.8.
 
 ::
 
-   M-x find-library RET anaconda-mode RET
+   M-: (dired (anaconda-mode-server-directory)) RET
    M-! rm -rf jedi* RET
    M-! pip install "jedi<0.9" -t . RET
 


### PR DESCRIPTION
As of around ff806b21, anaconda-mode no longer installs its Python
dependencies into the same directory as anaconda-mode.el.  Instruct
users to instead refer to (anaconda-mode-server-directory), which is the
new way to find out where Anaconda has installed its dependencies.