### PR TITLE
A simple bugfix for #124

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -346,7 +346,7 @@ submitted."
                           (not (equal anaconda-mode-request-point (point)))
                           (not (equal anaconda-mode-request-tick (buffer-chars-modified-tick))))))
                 (message "Skip anaconda-mode %s response" command)
-              (goto-char url-http-end-of-headers)
+              (goto-char (re-search-forward "^\r?$" nil t))
               (let* ((json-array-type 'list)
                      (response (condition-case nil
                                    (json-read)


### PR DESCRIPTION
Use re-search-forward instead of url-http-end-of-headers. See also: http://debbugs.gnu.org/cgi/bugreport.cgi?bug=13598