### PR TITLE
Don't flash `*http... *` buffers when using eldoc.

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -468,7 +468,10 @@ submitted."
 
 (defun anaconda-mode-eldoc-function ()
   "Show eldoc for context at point."
-  (anaconda-mode-call "eldoc" anaconda-mode-eldoc-callback))
+  (anaconda-mode-call "eldoc" anaconda-mode-eldoc-callback)
+  ;; Since anaconda-mode-eldoc-callback calls `eldoc-message'
+  ;; directly, return nil to eldoc.
+  nil)
 
 (defun anaconda-mode-eldoc-callback (result)
   "Display eldoc from server RESULT."


### PR DESCRIPTION
The return value of `eldoc-documentation-function` is displayed by
`eldoc-message`, but since `anaconda-mode-call` uses a callback, its
return value is simply the HTTP buffer from `anaconda-mode-jsonrpc`.

As a result, every time point moves, the minibuffer briefly flashes the
buffer name, which is distracting.