### PR TITLE
Force system scheme for installation of pip packages

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -138,7 +138,14 @@ else:
 import os, sys, pip
 directory = os.path.expanduser(sys.argv[-2])
 version = sys.argv[-1]
-pip.main(['install', '--system', '-t', directory, 'anaconda_mode==' + version])
+pip_args = ['install']
+# Ensure older pips do not try to use user scheme when installing.
+# This was default behaviour outside virtualenv before pip 6
+pip_major_version = int(pip.__version__.split('.')[0])
+if pip_major_version < 6:
+    pip_args.append('--system')
+pip_args.extend(['-t', directory, 'anaconda_mode==' + version])
+pip.main(pip_args)
 " "Install `anaconda_mode' server.")
 
 (defun anaconda-mode-server-directory ()

--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -138,7 +138,7 @@ else:
 import os, sys, pip
 directory = os.path.expanduser(sys.argv[-2])
 version = sys.argv[-1]
-pip.main(['install', '-t', directory, 'anaconda_mode==' + version])
+pip.main(['install', '--system', '-t', directory, 'anaconda_mode==' + version])
 " "Install `anaconda_mode' server.")
 
 (defun anaconda-mode-server-directory ()


### PR DESCRIPTION
According to pip documentation, as seen on some versions of Ubuntu, if
you're running installation outside of a virtual environment, the
default is to use user scheme, as if --user was specified. This,
however, conflicts with -t option.

This change forces using the system scheme to enable using install base
option, which would really just override the locations specified by user
scheme anyway. As a result, the default server installation command
becomes more robust, working as intended under wider set of
circumstances.

Related to issue #113 / #114 