### PR TITLE
Replace pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Supported Python Versions
 Installation
 ------------
 
-To use this package you need to install ``pip``.
+To use this package you need to install ``setuptools``.
 
 package.el
 ``````````
@@ -254,24 +254,6 @@ issue.
 
 Issues
 ------
-
-DistutilsOptionError
-````````````````````
-
-::
-
-    DistutilsOptionError: must supply either home or prefix/exec-prefix -- not both
-
-This occurs due to `distutils bug
-<http://bugs.python.org/issue22269>`_ when ``pip -t`` option conflict
-with ``distutils.cfg`` ``prefix`` option.  If you install ``pip`` with
-``homebrew`` you are on fire.  There are few options to avoid this
-issue.
-
-- install ``anaconda-mode`` `dependencies
-  <https://github.com/proofit404/anaconda-mode/blob/master/requirements.txt>`_
-  manually
-- remove ``prefix`` option from ``distutils.cfg``
 
 AttributeError and KeyError randomly happens
 ````````````````````````````````````````````

--- a/anaconda_mode.py
+++ b/anaconda_mode.py
@@ -101,7 +101,9 @@ def eldoc(script):
 
 app = [complete, goto_definitions, goto_assignments, usages, eldoc]
 
+def main(args):
+    host = args[0] if len(args) == 1 else '127.0.0.1'
+    service_factory(app, host, 'auto', 'anaconda_mode port {port}')
 
 if __name__ == '__main__':
-    host = sys.argv[1] if len(sys.argv) == 2 else '127.0.0.1'
-    service_factory(app, host, 'auto', 'anaconda_mode port {port}')
+    main(sys.argv[1:])


### PR DESCRIPTION
New and improved way of installing and running the python server that does not use pip, avoiding all the distutils.cfg and Debian issues. Instead it uses easy_install, installing server as eggs.

I have managed to make the changes entirely backward compatible, so it is not necessary to increase version number of the python package, or submit new version to PyPI before running the test suite.

I took the liberty of updating README accordingly, by replacing dependency on pip with setuptools and removing the reference to #113, which is a non-issue now (I have tested this on mac with homebrew installation).

**NOTE**: I have run tox locally after changing /bin/true to /usr/bin/true, and it all succeeded. However, I have not added tests for the backward compatibility with previous installation procedure. It's late, and you would probably have better idea how to test this, and *if* it should be tested. It might be easier to just bump version numbers after all. Providing backward compatibility was quite trivial, so I did it to make it easier for me to test that it works.

Fixes #113 and #114, this time for real, I think ;-)