### PR TITLE
Don’t switch to the process buffer upon error

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -114,7 +114,7 @@ anaconda_mode.main(sys.argv[1:])
 
 (defun anaconda-mode-show-process-buffer ()
   "Display `anaconda-mode-process-buffer'."
-  (pop-to-buffer anaconda-mode-process-buffer))
+  (display-buffer anaconda-mode-process-buffer))
 
 (defvar anaconda-mode-process-fail-hook nil
   "Hook running when any of `anaconda-mode' fails by some reason.")


### PR DESCRIPTION
Proposal to fix #235

When the process buffer (`*anaconda-mode*`) is to be shown, display the buffer, but don’t switch focus to it.