### PR TITLE
Don’t switch to the process buffer upon error

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -114,7 +114,8 @@ anaconda_mode.main(sys.argv[1:])
 
 (defun anaconda-mode-show-process-buffer ()
   "Display `anaconda-mode-process-buffer'."
-  (pop-to-buffer anaconda-mode-process-buffer))
+  (let ((buffer (get-buffer-create anaconda-mode-process-buffer)))
+    (display-buffer buffer)))
 
 (defvar anaconda-mode-process-fail-hook nil
   "Hook running when any of `anaconda-mode' fails by some reason.")


### PR DESCRIPTION
Attempt 2 to fix #235, for reverted PR #237.

Now if the process buffer doesn’t exist yet, it will be automatically created.