### PR TITLE
NotFoundError is no longer in jedi

### DIFF
--- a/anaconda_mode.py
+++ b/anaconda_mode.py
@@ -14,7 +14,7 @@ from __future__ import (
 import sys
 from functools import wraps
 
-from jedi import Script, NotFoundError
+from jedi import Script
 from service_factory import service_factory
 
 
@@ -23,10 +23,7 @@ def script_method(f):
 
     @wraps(f)
     def wrapper(source, line, column, path):
-        try:
-            return f(Script(source, line, column, path))
-        except NotFoundError:
-            return []
+        return f(Script(source, line, column, path))
 
     return wrapper
 


### PR DESCRIPTION
`NotFoundError` was removed from jedi today in commit d6a04b29280faaa4309f97390668cadc3a38a46a . I looked at the jedi source code, and it looks like jedi hasn't actually raised `NotFoundError` since 2015. Therefore I think this change is safe --- it will work with new versions of jedi which removed this exception, but it would work with other jedi versions going back the last two years.