### PR TITLE
Ensure anaconda-mode does not break on full name

### DIFF
--- a/anaconda_mode.py
+++ b/anaconda_mode.py
@@ -40,19 +40,25 @@ def process_definitions(f):
     @wraps(f)
     def wrapper(script):
 
-        return [{'name': definition.name,
+        json_out = []
+        for definition in f(script):
+            try:
+                signature = definition.full_name
+            except AttributeError:
+                signature = definition.name
+            json_out.append(
+                {'name': definition.name,
                  'type': definition.type,
                  'module-name': definition.module_name,
                  'module-path': definition.module_path,
                  'line': definition.line,
                  'column': definition.column,
-                 'docstring': definition.docstring(),
+                 'docstring': definition.docstring(raw=True),
                  'description': definition.description,
-                 'full-name': definition.full_name}
-                for definition in f(script)]
+                 'full-name': signature})
+        return json_out
 
     return wrapper
-
 
 @script_method
 @process_definitions


### PR DESCRIPTION
The `process_definitions` function in anaconda-mode assumes every definition to have a full name. However, sometimes the full name is not retrievable resulting in some kind of Implicit namespace error. Following the example in the Python plugin of VSCode, we could be a little more conservative and _try_ to retrieve the full name, and if it fails, use the regular name. This PR does just that.