### PR TITLE
Fix bug when using IPython

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -100,7 +100,7 @@
 import sys, site
 site.addsitedir('.')
 import anaconda_mode
-anaconda_mode.main(sys.argv[1:])
+anaconda_mode.main(sys.argv[-2:])
 " "Run `anaconda-mode' server.")
 
 (defvar anaconda-mode-process-name "anaconda-mode"


### PR DESCRIPTION
Attemp to fix #284
Python and IPython behave differently with sys.argv
```
> python -c "import sys;print(sys.argv)" foo bar
['-c', 'foo', 'bar']
> ipython -c "import sys;print(sys.argv)" foo bar
['/usr/bin/ipython', '-c', 'import sys;print(sys.argv)', 'foo', 'bar']
```

So `sys.argv[1:]` will pass 2 extra arguments when using IPython, which results in an AssertionError.
Change it to `sys.argv[-2:]` may be better