### PR TITLE
Make sure provided packages have precedence

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -98,7 +98,9 @@
 
 (defvar anaconda-mode-server-command "
 import sys, site
+sys.path, remainder = sys.path[:1], sys.path[1:]
 site.addsitedir('.')
+sys.path.extend(remainder)
 import anaconda_mode
 anaconda_mode.main(sys.argv[-2:])
 " "Run `anaconda-mode' server.")


### PR DESCRIPTION
I have done some experiments and I believe that the problem with #285 is that `site.addsitedir` does not manipulate the PYTHONPATH in a way that results in the provided packages (those downloaded by easy_install and saved in a specific directory) having higher precedence. That way, if a `jedi` package is already present in the environment, it will have precedence, which is what we want to avoid. I have thus used the solution found in this thread to tackle the problem:

https://bugs.python.org/issue7744

and it seems to work..