### PR TITLE
Fix byte compiler warnings

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -333,7 +333,7 @@ be bound."
                                 :query-on-exit nil
                                 :filter (lambda (process output)
                                           (anaconda-mode-bootstrap-filter process output callback))
-                                :sentinel (lambda (process event))
+                                :sentinel (lambda (_process _event))
                                 :args `("-c"
                                         ,anaconda-mode-server-command
                                         ,(anaconda-mode-server-directory)
@@ -429,7 +429,7 @@ number position, column number position and file path."
                (path . ,(when (buffer-file-name)
                           (pythonic-python-readable-file-name (buffer-file-name))))))))
 
-(defun anaconda-mode-create-response-handler (command callback)
+(defun anaconda-mode-create-response-handler (_command callback)
   "Create server response handler based on COMMAND and CALLBACK function.
 COMMAND argument will be used for response skip message.
 Response can be skipped if point was moved sense request was
@@ -525,8 +525,8 @@ submitted."
     (with-current-buffer buf
       (view-mode -1)
       (erase-buffer)
-      (--map
-       (progn
+      (mapc
+       (lambda (it)
          (insert (propertize (aref it 0) 'face 'bold))
          (insert "\n")
          (insert (s-trim-right (aref it 1)))

--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -410,7 +410,7 @@ number position, column number position and file path."
         (url-request-data (anaconda-mode-jsonrpc-request command)))
     (url-retrieve
      (format "http://%s:%s" (anaconda-mode-host) anaconda-mode-port)
-     (anaconda-mode-create-response-handler command callback)
+     (anaconda-mode-create-response-handler callback)
      nil
      t)))
 
@@ -429,11 +429,8 @@ number position, column number position and file path."
                (path . ,(when (buffer-file-name)
                           (pythonic-python-readable-file-name (buffer-file-name))))))))
 
-(defun anaconda-mode-create-response-handler (_command callback)
-  "Create server response handler based on COMMAND and CALLBACK function.
-COMMAND argument will be used for response skip message.
-Response can be skipped if point was moved sense request was
-submitted."
+(defun anaconda-mode-create-response-handler (callback)
+  "Create server response handler based on CALLBACK function."
   (let ((anaconda-mode-request-point (point))
         (anaconda-mode-request-buffer (current-buffer))
         (anaconda-mode-request-window (selected-window))


### PR DESCRIPTION
Fixes these warnings:

```
anaconda-mode.el:326:1:Warning: Unused lexical argument ‘event’
anaconda-mode.el:326:1:Warning: Unused lexical argument ‘process’
anaconda-mode.el:432:1:Warning: Unused lexical argument ‘command’

In anaconda-mode-documentation-view:
anaconda-mode.el:527:8:Warning: ‘mapcar’ called for effect; use ‘mapc’ or
    ‘dolist’ instead
```