### PR TITLE
(#305) check for more generic pythonic-ssh-p instead of vagrant

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -388,7 +388,7 @@ called when `anaconda-mode-port' will be bound."
                                     (format "TCP4-LISTEN:%d" (anaconda-mode-port))
                                     (format "TCP4:%s:%d" container-ip (anaconda-mode-port))))
                (set-process-query-on-exit-flag anaconda-mode-socat-process nil)))
-            ((pythonic-remote-vagrant-p)
+            ((pythonic-remote-ssh-p)
              (setq anaconda-mode-ssh-process
                    (start-process anaconda-mode-ssh-process-name
                                   anaconda-mode-ssh-process-buffer


### PR DESCRIPTION
This is a PR which follows https://github.com/proofit404/pythonic/issues/6

The only thing that I'm not sure is possible breakage on package upgrade - like anaconda-mode updates, but pythonic is not. I'm not very familiar with how package-install works in this case. My guess is that users of melpa latest won't be noticing it since it always pulls latest changes, and users of melpa-stable use latest git tag, which is ok.

But I'm not 100% sure about that, so maybe before merging it we have to bump versions or something like that.