### PR TITLE
Fix some errors

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -315,8 +315,8 @@ be bound."
                      python-shell-interpreter)
               (equal (process-get anaconda-mode-process 'virtualenv)
                      python-shell-virtualenv-root)
-              (equal (not (process-get anaconda-mode-process 'remote-p))
-                     (not (pythonic-remote-p)))
+              (equal (process-get anaconda-mode-process 'remote-p)
+                     (pythonic-remote-p))
               (if (pythonic-local-p)
                   t
                 (equal (process-get anaconda-mode-process 'remote-method)

--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -315,8 +315,8 @@ be bound."
                      python-shell-interpreter)
               (equal (process-get anaconda-mode-process 'virtualenv)
                      python-shell-virtualenv-root)
-              (equal (process-get anaconda-mode-process 'remote-p)
-                     (pythonic-remote-p))
+              (equal (not (process-get anaconda-mode-process 'remote-p))
+                     (not (pythonic-remote-p)))
               (if (pythonic-local-p)
                   t
                 (equal (process-get anaconda-mode-process 'remote-method)
@@ -334,7 +334,7 @@ CALLBACK function will be called when `anaconda-mode-port' will
 be bound."
   (setq anaconda-mode-process
         (pythonic-start-process :process anaconda-mode-process-name
-                                :buffer anaconda-mode-process-buffer
+                                :buffer (get-buffer-create anaconda-mode-process-buffer)
                                 :query-on-exit nil
                                 :filter (lambda (process output)
                                           (anaconda-mode-bootstrap-filter process output callback))


### PR DESCRIPTION
1. I was getting an error about buffer `*anaconda-mode*` not existing; doing get-buffer-create before creating the subprocess seems to fix it.

2. pythonic-remote-p was returning `0` instead of `t`.  (This was causing anaconda-mode to think it needed to restart the subprocess every time.)  Coercing both sides of the `equal` to a boolean using `not` seems to fix this.