### PR TITLE
Change clearing method for missing_dependencies

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -127,7 +127,7 @@ def install_deps():
 if missing_dependencies:
     install_deps()
 
-missing_dependencies.clear()
+del missing_dependencies[:]
 
 try:
     import jedi


### PR DESCRIPTION
This PR is related to [issue#329 ](https://github.com/proofit404/anaconda-mode/issues/329) and will ensure backwards comptability with python2.7