### PR TITLE
Fix Python 2 compatibility by using different syntax for list.clear

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -127,7 +127,7 @@ def install_deps():
 if missing_dependencies:
     install_deps()
 
-missing_dependencies.clear()
+del missing_dependencies[:]
 
 try:
     import jedi


### PR DESCRIPTION
`list.clear()` exists only from on Python 3.2+

Fix #329 