### PR TITLE
Fix assertion failure on Emacs 27 for xref

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -652,7 +652,16 @@ Show ERROR-MESSAGE if result is empty."
   (if result
       (if (stringp result)
           (message result)
-        (xref--show-xrefs (anaconda-mode-make-xrefs result) display-action))
+        (let ((xrefs (anaconda-mode-make-xrefs result)))
+          (if (not (cdr xrefs))
+              (progn
+                (xref-push-marker-stack)
+                (xref--pop-to-location (cl-first xrefs)
+                                       (assoc-default 'display-action display-action)))
+            (xref--show-xrefs (if (functionp 'xref--create-fetcher)
+                                  (-const xrefs)
+                                xrefs)
+                              display-action))))
     (message error-message)))
 
 (defun anaconda-mode-make-xrefs (result)


### PR DESCRIPTION
Emacs 27 changes `xref--show-xrefs` to accept a function as the 1st argument.

This commit attempts to fix that issue based on several discussion and by copying almost every line from several commits from this link:
https://github.com/emacs-lsp/lsp-mode/issues/898

I've written only a few lines of Elisp before, so please let me know if anything done here is inappropriate or incorrect.

Also, I've minimally tested it under Spacemacs develop branch w/ Emacs 26.1 and 27.0.50.

HTH.